### PR TITLE
Add Book Card style and apply absolute import

### DIFF
--- a/components/book/BookCard/BookCard.module.scss
+++ b/components/book/BookCard/BookCard.module.scss
@@ -1,8 +1,5 @@
 .bookCard {
-  max-width: 400px;
   cursor: pointer;
-  text-decoration: none;
-  padding-bottom: var(--space-md);
 
   .image {
     margin-bottom: var(--space-md);

--- a/components/book/BookCard/BookCard.module.scss
+++ b/components/book/BookCard/BookCard.module.scss
@@ -1,0 +1,36 @@
+.bookCard {
+  max-width: 400px;
+  cursor: pointer;
+  text-decoration: none;
+  padding-bottom: var(--space-md);
+
+  .image {
+    margin-bottom: var(--space-md);
+  }
+
+  .details {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    font-weight: var(--semibold);
+
+    .district {
+      font-size: var(--text-sm);
+      color: var(--text-color-secondary);
+    }
+
+    .heading {
+      width: 100%;
+      font-size: var(--text-lg);
+      text-align: center;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      line-height: var(--dense);
+    }
+    .price {
+      color: var(--green-80);
+      font-size: var(--text-md);
+    }
+  }
+}

--- a/components/book/BookCard/BookCard.tsx
+++ b/components/book/BookCard/BookCard.tsx
@@ -1,19 +1,36 @@
 import React from 'react'
 import Image from 'next/image'
-import { Book } from '../../../types'
+import Link from 'next/link'
+
+import { Book } from 'types'
+import { formatPrice } from 'utils/formatPrice'
+
+import styles from './BookCard.module.scss'
 
 const BookCard = ({ book }: { book: Book; eager: boolean }) => {
+  const {
+    title,
+    user: {
+      district: { name: districtName },
+    },
+    price,
+    pictures: [firstPicture],
+  } = book
   return (
-    <div>
-      <Image
-        alt="book picture"
-        width="250"
-        height="300"
-        src={book.pictures[0]}
-      />
-      <label>{book.title}</label>
-      <p>{book.author}</p>
-    </div>
+    <Link
+      className={styles.bookCard}
+      href="#"
+      aria-label={`View ${title} book page`}
+    >
+      <div className={styles.image} data-name="book-image-box">
+        <Image alt={title} width="224" height="224" src={firstPicture} />
+      </div>
+      <div className={styles.details}>
+        <div className={styles.district}>{districtName}</div>
+        <h2 className={styles.heading}>{title}</h2>
+        <div className={styles.price}>{formatPrice(price)}</div>
+      </div>
+    </Link>
   )
 }
 

--- a/components/book/BookCard/BookCard.tsx
+++ b/components/book/BookCard/BookCard.tsx
@@ -7,7 +7,7 @@ import { formatPrice } from 'utils/formatPrice'
 
 import styles from './BookCard.module.scss'
 
-const BookCard = ({ book }: { book: Book; eager: boolean }) => {
+const BookCard = ({ book }: { book: Book }) => {
   const {
     title,
     user: {

--- a/components/book/BookCard/BookCard.tsx
+++ b/components/book/BookCard/BookCard.tsx
@@ -16,6 +16,7 @@ const BookCard = ({ book }: { book: Book; eager: boolean }) => {
     price,
     pictures: [firstPicture],
   } = book
+
   return (
     <Link
       className={styles.bookCard}

--- a/components/book/BooksList/BookList.module.css
+++ b/components/book/BooksList/BookList.module.css
@@ -1,4 +1,4 @@
-.listingContainerStyle {
+.listingContainer {
   display: grid;
   grid-template-columns: var(--product-grid);
   place-items: center;

--- a/components/book/BooksList/BookList.tsx
+++ b/components/book/BooksList/BookList.tsx
@@ -8,8 +8,8 @@ import styles from './BookList.module.css'
 const BookList = ({ books }: { books: Book[] }) => {
   return (
     <div className={styles.listingContainer}>
-      {books.map((b, index) => (
-        <BookCard book={b} key={b.id} eager={index === 0} />
+      {books.map((b) => (
+        <BookCard book={b} key={b.id} />
       ))}
     </div>
   )

--- a/components/book/BooksList/BookList.tsx
+++ b/components/book/BooksList/BookList.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
-import { Book } from '../../../types'
+
+import { Book } from 'types'
+
 import BookCard from '../BookCard'
 import styles from './BookList.module.css'
 
 const BookList = ({ books }: { books: Book[] }) => {
   return (
-    <div className={styles.listingContainerStyle}>
+    <div className={styles.listingContainer}>
       {books.map((b, index) => (
         <BookCard book={b} key={b.id} eager={index === 0} />
       ))}

--- a/styles/reset.css
+++ b/styles/reset.css
@@ -64,7 +64,7 @@ sup {
 }
 
 img {
-  border-style: none;
+  border-radius: var(--radius-sm);
 }
 
 button,

--- a/styles/reset.css
+++ b/styles/reset.css
@@ -8,20 +8,6 @@ html {
   touch-action: manipulation;
 }
 
-body {
-  position: relative;
-  min-height: 100%;
-  font-feature-settings: "kern";
-}
-
-*,
-*::before,
-*::after {
-  border-width: 0;
-  border-style: solid;
-  box-sizing: border-box;
-}
-
 main {
   display: block;
 }
@@ -42,9 +28,7 @@ samp {
 }
 
 a {
-  background-color: transparent;
   color: inherit;
-  text-decoration: inherit;
 }
 
 abbr[title] {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -14,8 +18,18 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "typeRoots": ["./node_modules/@types", "./types"]
+    "typeRoots": [
+      "./node_modules/@types",
+      "./types"
+    ],
+    "baseUrl": "."
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,6 +5,11 @@ declare global {
   }
 }
 
+export type District = {
+  id: string
+  name: string
+}
+
 export type User = {
   id: string
   email: string
@@ -15,6 +20,7 @@ export type User = {
   sid: string
   sub: string
   description: string
+  district: District
   updated_at: string
 }
 

--- a/utils/formatPrice.ts
+++ b/utils/formatPrice.ts
@@ -1,0 +1,11 @@
+/**
+ * Formats a currency according to the user's locale
+ * @param {string} currency The ISO currency code
+ * @param {number} value The amount to format
+ * @returns
+ */
+export const formatPrice = (value: number, currency = 'VND') =>
+  Intl.NumberFormat('de-DE', {
+    currency,
+    style: 'currency',
+  }).format(value)

--- a/utils/formatPrice.ts
+++ b/utils/formatPrice.ts
@@ -1,8 +1,8 @@
 /**
  * Formats a currency according to the user's locale
- * @param {string} currency The ISO currency code
  * @param {number} value The amount to format
- * @returns
+ * @param {string} currency The ISO currency code
+ * @returns price with currency
  */
 export const formatPrice = (value: number, currency = 'VND') =>
   Intl.NumberFormat('de-DE', {


### PR DESCRIPTION
## Description
 - Populate book card styles from the gatsby repo [product-card.module.css](https://github.com/gatsbyjs/gatsby-starter-shopify/blob/27d34d9510298df5ee5a36da35ced572ada53317/src/components/product-card.module.css).
 - Display district and formatted money on book cards.
 - Apply absolute import.

## TODO
- [ ] Make card content align 

## Next steps
- Header
- View book detail
- More books

## Result
<img width="1118" alt="Screenshot 2023-03-04 at 15 56 19" src="https://user-images.githubusercontent.com/14868839/222886724-69fb96b2-0b46-402a-9a97-00c483a3d72c.png">