### PR TITLE
feat(home-page): apply server rendering and add more books button

### DIFF
--- a/components/book/MoreBookList/MoreBookList.test.tsx
+++ b/components/book/MoreBookList/MoreBookList.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, screen } from '@testing-library/react'
+
+import { clientGraphqlRequest } from 'lib/harsura'
+import { Book } from 'types'
+import { books, book3, book2 } from 'test-utils/__mocks__/mockedBooks'
+import { renderWithQueryClient } from 'test-utils/setup'
+import { waitForLoadingToBeDone } from 'test-utils/common'
+
+import MoreBookList from './MoreBookList'
+
+const mockedRequest = clientGraphqlRequest as unknown as jest.Mock<
+  Promise<{ books: Book[] }>,
+  [string, { genreIds: [string] }]
+>
+
+describe('MoreBookList', () => {
+  afterEach(() => {
+    mockedRequest.mockReset()
+  })
+
+  it('should render book list and more button', async () => {
+    mockedRequest.mockReturnValueOnce(Promise.resolve({ books }))
+
+    renderWithQueryClient(<MoreBookList isError={false} />)
+    await waitForLoadingToBeDone()
+
+    const book1Elm = screen.getByText('Book 1')
+    const book2Elm = screen.getByText('Book 2')
+    expect(book1Elm).toBeInTheDocument()
+    expect(book2Elm).toBeInTheDocument()
+  })
+
+  it('should able to render book list by genre', async () => {
+    mockedRequest.mockImplementation((_query, { genreIds }) => {
+      if (genreIds.toString() === 'genre-2')
+        return Promise.resolve({ books: [book2] })
+      return Promise.resolve({ books })
+    })
+
+    renderWithQueryClient(<MoreBookList isError={false} genreId="genre-2" />)
+    await waitForLoadingToBeDone()
+
+    const book1Elm = screen.queryByText('Book 1')
+    const book2Elm = screen.getByText('Book 2')
+    expect(book1Elm).toBeNull()
+    expect(book2Elm).toBeInTheDocument()
+  })
+
+  it('click "More Books" should display more books', async () => {
+    jest.mock('hooks/useBooks', () => {
+      return {
+        ...jest.requireActual('hooks/useBooks'),
+        DEFAULT_BOOKS_LIMIT: 2,
+      }
+    })
+    mockedRequest
+      .mockReturnValueOnce(Promise.resolve({ books }))
+      .mockResolvedValueOnce(Promise.resolve({ books: [...books, book3] }))
+
+    renderWithQueryClient(<MoreBookList isError={false} />)
+    await waitForLoadingToBeDone()
+
+    const book1Elm = screen.getByText('Book 1')
+    const book2Elm = screen.getByText('Book 2')
+    expect(book1Elm).toBeInTheDocument()
+    expect(book2Elm).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('More Books', { selector: 'button' }))
+
+    await waitForLoadingToBeDone()
+
+    const book3Elm = screen.getByText('Book 3')
+    expect(book3Elm).toBeInTheDocument()
+
+    jest.resetAllMocks()
+  })
+})

--- a/components/book/MoreBookList/MoreBookList.tsx
+++ b/components/book/MoreBookList/MoreBookList.tsx
@@ -1,0 +1,28 @@
+import { DEFAULT_BOOKS_LIMIT, useBooks } from 'hooks/useBooks'
+import { BookList } from 'components/book'
+import { useState } from 'react'
+
+type MoreBookListProps = {
+  isError: any
+  genreId?: string | string[]
+}
+
+const MoreBookList = ({ isError, genreId }: MoreBookListProps) => {
+  const [limit, setLimit] = useState(DEFAULT_BOOKS_LIMIT)
+  const { data, isLoading } = useBooks(limit, genreId)
+
+  const onClickMore = () => {
+    setLimit(limit + 2)
+  }
+
+  return (
+    <div>
+      {isError && <p>Error happens</p>}
+      {isLoading && <p>Loading</p>}
+      {data && <BookList books={data.books} />}
+      <button onClick={onClickMore}>More Books</button>
+    </div>
+  )
+}
+
+export default MoreBookList

--- a/components/book/MoreBookList/MoreBookList.tsx
+++ b/components/book/MoreBookList/MoreBookList.tsx
@@ -1,6 +1,7 @@
+import { useState } from 'react'
+
 import { DEFAULT_BOOKS_LIMIT, useBooks } from 'hooks/useBooks'
 import { BookList } from 'components/book'
-import { useState } from 'react'
 
 type MoreBookListProps = {
   isError: any
@@ -12,7 +13,7 @@ const MoreBookList = ({ isError, genreId }: MoreBookListProps) => {
   const { data, isLoading } = useBooks(limit, genreId)
 
   const onClickMore = () => {
-    setLimit(limit + 2)
+    setLimit(limit + DEFAULT_BOOKS_LIMIT)
   }
 
   return (

--- a/components/book/MoreBookList/index.ts
+++ b/components/book/MoreBookList/index.ts
@@ -1,0 +1,1 @@
+export { default as MoreBookList } from './MoreBookList'

--- a/hooks/useBooks.ts
+++ b/hooks/useBooks.ts
@@ -1,6 +1,8 @@
-import { clientGraphqlRequest } from '../lib/harsura'
 import { gql } from 'graphql-request'
 import { useQuery } from '@tanstack/react-query'
+
+import { clientGraphqlRequest } from 'lib/harsura'
+
 import { Book } from '../types'
 
 export const DEFAULT_BOOKS_LIMIT = 5

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -4,3 +4,8 @@
 // Used for __tests__/testing-library.js
 // Learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom/extend-expect'
+
+jest.mock('lib/harsura', () => ({
+  clientGraphqlRequest: jest.fn(),
+  graphqlRequest: jest.fn(),
+}))

--- a/lib/harsura.ts
+++ b/lib/harsura.ts
@@ -1,12 +1,13 @@
-import request from 'graphql-request'
+import request, { Variables } from 'graphql-request'
 
-export default function graphqlRequest<T>(query: string, params: object) {
+export default function graphqlRequest<T>(query: string, params: Variables) {
   return request<T>(process.env.API_ENDPOINT || '', query, params, {
     'x-hasura-admin-secret': process.env.HASURA_ADMIN_SECRET || '',
   })
 }
 
-function clientGraphqlRequest<T>(query: string, params: object) {
+// TODO: alow controlling variables type
+function clientGraphqlRequest<T>(query: string, params: Variables) {
   return request<T>(process.env.NEXT_PUBLIC_API_ENDPOINT || '', query, params, {
     'x-hasura-admin-secret': process.env.NEXT_PUBLIC_HASURA_ADMIN_SECRET || '',
   })

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest --watch",
+    "test": "jest",
+    "test:watch": "jest --watch",
     "test:ci": "jest --ci"
   },
   "dependencies": {

--- a/pages/books/[genreId].tsx
+++ b/pages/books/[genreId].tsx
@@ -1,0 +1,44 @@
+import { dehydrate, QueryClient } from '@tanstack/react-query'
+import { GetServerSideProps, InferGetServerSidePropsType } from 'next'
+import Head from 'next/head'
+
+import { DEFAULT_BOOKS_LIMIT, fetchBooks } from 'hooks/useBooks'
+import { MoreBookList } from 'components/book/MoreBookList'
+
+export default function BookListByGenre({
+  isError,
+  genreId,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return (
+    <>
+      <Head>
+        <title>Book Market - {genreId}</title>
+      </Head>
+      <MoreBookList isError={isError} genreId={genreId} />
+    </>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ params }) => {
+  const genreId = params?.genreId
+  const queryClient = new QueryClient()
+
+  let isError = false
+  try {
+    // prefetch data on the server
+    await queryClient.fetchQuery(['books', DEFAULT_BOOKS_LIMIT, genreId], () =>
+      fetchBooks(DEFAULT_BOOKS_LIMIT, genreId)
+    )
+  } catch (err) {
+    isError = true
+  }
+
+  return {
+    props: {
+      genreId,
+      isError,
+      // dehydrate query cache
+      dehydratedState: dehydrate(queryClient),
+    },
+  }
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,21 +1,44 @@
 import Head from 'next/head'
-import { BookList } from '../components/book'
-import { useBooks } from '../hooks/useBooks'
+import { MoreBookList } from 'components/book/MoreBookList'
+import { GetServerSideProps, InferGetServerSidePropsType } from 'next'
+import { QueryClient, dehydrate } from '@tanstack/react-query'
+import { DEFAULT_BOOKS_LIMIT, fetchBooks } from 'hooks/useBooks'
 
-export default function Home() {
-  const { data, isLoading } = useBooks()
-
+export default function Home({
+  isError,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
     <>
       <Head>
-        <title>Book Market</title>
+        <title>Book Market - Home page</title>
         <meta name="description" content="a page to seek old books" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <main>
-        {isLoading && <p>Loading</p>}
-        {!isLoading && data && <BookList books={data.books} />}
+        <MoreBookList isError={isError} />
       </main>
     </>
   )
+}
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  const queryClient = new QueryClient()
+
+  let isError = false
+  try {
+    // prefetch data on the server
+    await queryClient.fetchQuery(['books', DEFAULT_BOOKS_LIMIT], () =>
+      fetchBooks(DEFAULT_BOOKS_LIMIT)
+    )
+  } catch (err) {
+    isError = true
+  }
+
+  return {
+    props: {
+      isError,
+      // dehydrate query cache
+      dehydratedState: dehydrate(queryClient),
+    },
+  }
 }

--- a/test-utils/__mocks__/mockedBooks.ts
+++ b/test-utils/__mocks__/mockedBooks.ts
@@ -33,12 +33,35 @@ export const book2: Book = {
   pictures: ['https://link-to-image-2'],
   isSold: false,
   genre: {
-    id: 'genre-1',
-    name: 'Tam ly',
+    id: 'genre-2',
+    name: 'Tieng Anh',
   },
   user: {
     id: 'user-1',
     email: 'user1@gmail.com',
+    district: {
+      id: 'district-2',
+      name: 'Quan 2',
+    },
+  },
+}
+
+export const book3: Book = {
+  id: 3,
+  title: 'Book 3',
+  author: 'Thanh',
+  price: 30000,
+  originalPrice: 50000,
+  description: 'This is book 3',
+  pictures: ['https://link-to-image-1'],
+  isSold: false,
+  genre: {
+    id: 'genre-2',
+    name: 'Tieng Anh',
+  },
+  user: {
+    id: 'user-2',
+    email: 'user2@gmail.com',
     district: {
       id: 'district-2',
       name: 'Quan 2',

--- a/test-utils/common.ts
+++ b/test-utils/common.ts
@@ -1,0 +1,5 @@
+import { screen, waitForElementToBeRemoved } from '@testing-library/react'
+
+export const waitForLoadingToBeDone = async () => {
+  await waitForElementToBeRemoved(() => screen.queryByText(/Loading/))
+}

--- a/test-utils/setup.tsx
+++ b/test-utils/setup.tsx
@@ -1,0 +1,9 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render } from '@testing-library/react'
+import { ReactNode } from 'react'
+
+export const renderWithQueryClient = (node: ReactNode) => {
+  const queryClient = new QueryClient()
+
+  render(<QueryClientProvider client={queryClient}>{node}</QueryClientProvider>)
+}


### PR DESCRIPTION
## Changes
- Add a new feature to allow loading more books
- Add `jest:watch` command
- Add relative unit tests
- Correct  params type of `graphqlRequest`

## Result
<img width="761" alt="Screenshot 2023-06-11 at 15 33 23" src="https://github.com/thaoho21294/book-market-nextjs/assets/14868839/e1d36d01-7394-407c-aa4c-068cdea1388e">

## Todo
- Improve UI of `More Books` button.
- Improve UI effect to not remove whole list when click `More Books` button.
- Allow controlling variables type
- Adjust query string to return camelCase format.
